### PR TITLE
Implemented PiMetadata in all executors

### DIFF
--- a/src/com/workflowfm/pew/PiEventHandler.scala
+++ b/src/com/workflowfm/pew/PiEventHandler.scala
@@ -80,7 +80,7 @@ case class PiEventResult[KeyT](
 case class PiEventCall[KeyT](
     override val id: KeyT,
     ref: Int,
-    p: AtomicProcess,
+    p: MetadataAtomicProcess,
     args: Seq[PiObject],
     override val metadata: PiMetadataMap = PiMetadata()
   ) extends PiAtomicProcessEvent[KeyT] {

--- a/src/com/workflowfm/pew/PiInstance.scala
+++ b/src/com/workflowfm/pew/PiInstance.scala
@@ -47,11 +47,11 @@ case class PiInstance[T](final val id:T, called:Seq[Int], process:PiProcess, sta
   
   def getProc(p:String):Option[PiProcess] = state.processes.get(p)
 
-  def getAtomicProc( name: String ): AtomicProcess = {
+  def getAtomicProc( name: String ): MetadataAtomicProcess = {
     getProc( name ) match {
       case None => throw UnknownProcessException( this, name )
       case Some( proc ) => proc match {
-        case atomic: AtomicProcess => atomic
+        case atomic: MetadataAtomicProcess => atomic
         case _: PiProcess => throw AtomicProcessIsCompositeException( this, name )
       }
     }

--- a/src/com/workflowfm/pew/PiMetadata.scala
+++ b/src/com/workflowfm/pew/PiMetadata.scala
@@ -22,9 +22,9 @@ object PiMetadata {
     * @param id The String key of the type of meta-data.
     * @tparam T The Scala-type of the type of meta-data.
     */
-  class Key[T]( val id: String ) extends (PiMetadataMap => T) {
+  case class Key[T]( val id: String ) extends (PiMetadataMap => T) {
     override def apply( meta: PiMetadataMap ): T
-      = meta(id).asInstanceOf[T]
+    = meta(id).asInstanceOf[T]
   }
 
   /** The system time (in milliseconds) when a PiEvent

--- a/src/com/workflowfm/pew/PiState.scala
+++ b/src/com/workflowfm/pew/PiState.scala
@@ -127,7 +127,7 @@ case class PiState(inputs:Map[Chan,Input], outputs:Map[Chan,Output], calls:List[
         System.err.println("Failed to find process: " + c.name)
         this
       }
-      case Some(p:AtomicProcess) => {
+      case Some(p:MetadataAtomicProcess) => {
         //System.err.println("*** Handling atomic call: " + c.name)
         val m = p.mapFreshArgs(freshCtr,c.args:_*)
         copy(calls = p.getFuture(freshCtr,m) +: calls) withTerms p.getInputs(freshCtr,m) incFCtr()

--- a/src/com/workflowfm/pew/execution/MultiStateExecutor.scala
+++ b/src/com/workflowfm/pew/execution/MultiStateExecutor.scala
@@ -82,13 +82,13 @@ class MultiStateExecutor(var store:PiInstanceStore[Int], processes:PiProcessStor
         System.err.println("*** [" + i.id + "] ERROR *** Unable to find process: " + name)
         false
       }
-      case Some(p:AtomicProcess) => {
+      case Some(p:MetadataAtomicProcess) => {
         val objs = args map (_.obj)
         publish(PiEventCall(i.id,ref,p,objs))
-        p.run(args map (_.obj)).onComplete{ 
+        p.runMeta(args map (_.obj)).onComplete{ 
           case Success(res) => {
-            publish(PiEventReturn(i.id,ref,PiObject.get(res)))
-            postResult(i.id,ref,res)
+            publish(PiEventReturn(i.id,ref,PiObject.get(res._1),res._2))
+            postResult(i.id,ref,res._1)
           }
           case Failure (ex) => publish(PiEventProcessException(i.id,ref,ex))
         }

--- a/src/com/workflowfm/pew/execution/SingleBlockingExecutor.scala
+++ b/src/com/workflowfm/pew/execution/SingleBlockingExecutor.scala
@@ -37,10 +37,10 @@ case class SingleBlockingExecutor(processes:Map[String,PiProcess])(implicit val 
         System.err.println("*** ERROR *** Unable to find process: " + name)
         Some(s removeThread ref)
       }
-      case Some(p:AtomicProcess) => {
-        val f = p.run(args map (_.obj))
+      case Some(p:MetadataAtomicProcess) => {
+        val f = p.runMeta(args map (_.obj))
         val res = Await.result(f,Duration.Inf)
-        s.result(ref,res)
+        s.result(ref,res._1)
       }
       case Some(p:CompositeProcess) => { System.err.println("*** Executor encountered composite process thread: " + name); None } // TODO this should never happen!
     }

--- a/src/com/workflowfm/pew/execution/SingleStateExecutor.scala
+++ b/src/com/workflowfm/pew/execution/SingleStateExecutor.scala
@@ -78,13 +78,13 @@ class SingleStateExecutor(processes:PiProcessStore)
         publish(PiFailureUnknownProcess(i, name))
         false
       }
-      case Some(p:AtomicProcess) => {
+      case Some(p:MetadataAtomicProcess) => {
         val objs = args map (_.obj)
         publish(PiEventCall(i.id,ref,p,objs))
-        p.run(objs).onComplete{ 
+        p.runMeta(objs).onComplete{ 
           case Success(res) => {
-            publish(PiEventReturn(i.id,ref,PiObject.get(res)))
-            postResult(i.id,ref,res)
+            publish(PiEventReturn(i.id,ref,PiObject.get(res._1),res._2))
+            postResult(i.id,ref,res._1)
           }
           case Failure(ex) => {
             publish(PiEventProcessException(i.id,ref,ex))

--- a/src/com/workflowfm/pew/stateless/components/Reducer.scala
+++ b/src/com/workflowfm/pew/stateless/components/Reducer.scala
@@ -48,7 +48,7 @@ class Reducer(
     f match {
       case PiFuture(name, _, _) => i.getProc(name) match {
 
-        case Some(_: AtomicProcess) => true
+        case Some(_: MetadataAtomicProcess) => true
 
         case None => throw UnknownProcessException( i, name )
         case Some(_) => throw AtomicProcessIsCompositeException( i, name )
@@ -63,7 +63,7 @@ class Reducer(
         piReduced.getProc(name) match {
 
           // Request that the process be executed.
-          case Some(p: AtomicProcess) => Seq(
+          case Some(p: MetadataAtomicProcess) => Seq(
             Assignment( piReduced, ref, p.name, args ),
             PiiLog( PiEventCall( piiId, ref.id, p, args map (_.obj) ) )
           )

--- a/src/com/workflowfm/pew/stateless/instances/kafka/KafkaExecutor.scala
+++ b/src/com/workflowfm/pew/stateless/instances/kafka/KafkaExecutor.scala
@@ -36,7 +36,7 @@ object CompleteKafkaExecutor {
     new CustomKafkaExecutor(
       indySequencer,
       indyReducer( new Reducer ),
-      indyAtomicExecutor( AtomicExecutor() )
+      indyAtomicExecutor( new AtomicExecutor() )
     )
   }
 

--- a/test/com/workflowfm/pew/execution/CodeOutputTests.scala
+++ b/test/com/workflowfm/pew/execution/CodeOutputTests.scala
@@ -313,7 +313,7 @@ class GetSki(cM2Inch : CM2Inch,selectLength : SelectLength,selectModel : SelectM
 	override val body = PiCut("z14","x12","oSelectSki_lB_PriceUSD_Plus_Exception_rB_",WithIn("x12","cUSD2NOK_PriceUSD_1","c12",LeftOut("y12","oUSD2NOK_PriceNOK_",PiCall<("USD2NOK","cUSD2NOK_PriceUSD_1","oUSD2NOK_PriceNOK_")),RightOut("y12","d12",PiId("c12","d12","m13"))),PiCut("z9","z8","oSelectModel_lB_Brand_x_Model_rB_",ParInI("z8","cSelectSki_Brand_2","cSelectSki_Model_3",PiCut("z4","cSelectSki_LengthInch_1","oCM2Inch_LengthInch_",PiCall<("SelectSki","cSelectSki_LengthInch_1","cSelectSki_Brand_2","cSelectSki_Model_3","oSelectSki_lB_PriceUSD_Plus_Exception_rB_"),PiCut("z2","cCM2Inch_LengthCM_1","oSelectLength_LengthCM_",PiCall<("CM2Inch","cCM2Inch_LengthCM_1","oCM2Inch_LengthInch_"),PiCall<("SelectLength","cSelectLength_HeightCM_1","cSelectLength_WeightKG_2","oSelectLength_LengthCM_")))),PiCall<("SelectModel","cSelectModel_PriceLimit_1","cSelectModel_SkillLevel_2","oSelectModel_lB_Brand_x_Model_rB_")))
 	
 	def apply(heightCM : HeightCM,priceLimit : PriceLimit,skillLevel : SkillLevel,weightKG : WeightKG)(implicit executor:ProcessExecutor[_]): Future[Either[PriceNOK,Exception]] = {
-	  implicit val context:ExecutionContext = executor.context 
+	  implicit val context:ExecutionContext = executor.executionContext 
 		executor.execute(this,Seq(heightCM,priceLimit,skillLevel,weightKG)).map(_.asInstanceOf[Either[PriceNOK,Exception]])
 	}
 }

--- a/test/com/workflowfm/pew/execution/ExecutorTests.scala
+++ b/test/com/workflowfm/pew/execution/ExecutorTests.scala
@@ -86,7 +86,7 @@ package object RexampleTypes
     override val body = PiCut("z16","z15","z5",ParInI("z15","buf13","cPc_B_1",ParOut("z13","b13","oPc_Z_",PiId("buf13","b13","m14"),PiCall<("Pc","cPc_B_1","oPc_Z_"))),PiCut("z8","z7","oPa_lB_A_x_B_rB_",ParInI("z7","cPb_A_1","buf5",ParOut("z5","oPb_Y_","b5",PiCall<("Pb","cPb_A_1","oPb_Y_"),PiId("buf5","b5","m6"))),PiCall<("Pa","cPa_X_1","oPa_lB_A_x_B_rB_")))
     
     def apply(x:X)(implicit executor:ProcessExecutor[_]): Future[(Y,Z)] = {
-	  implicit val context:ExecutionContext = executor.context
+	  implicit val context:ExecutionContext = executor.executionContext 
 	  executor.execute(this,Seq(x)).map(_.asInstanceOf[(Y,Z)])
     }
   }
@@ -102,7 +102,7 @@ package object RexampleTypes
     override val body = PiCut("z16","z15","z5",ParInI("z15","buf13","cPc_B_1",ParOut("z13","b13","oPc_Z_",PiId("buf13","b13","m14"),PiCall<("Pc","cPc_B_1","oPc_Z_"))),PiCut("z8","z7","oPa_lB_A_x_B_rB_",ParInI("z7","cPb_A_1","buf5",ParOut("z5","oPb_Y_","b5",PiCall<("Pb","cPb_A_1","oPb_Y_"),PiId("buf5","b5","m6"))),PiCall<("Pa","cPa_X_1","oPa_lB_A_x_B_rB_")))
     
     def apply(x:X)(implicit executor:ProcessExecutor[_]): Future[Option[(Y,Z)]] = {
-  	  implicit val context:ExecutionContext = executor.context
+  	  implicit val context:ExecutionContext = executor.executionContext 
   	  executor.execute(this,Seq(x)).map(_.asInstanceOf[Option[(Y,Z)]])
     }
   }

--- a/test/com/workflowfm/pew/mongodb/MongoExecutorTests.scala
+++ b/test/com/workflowfm/pew/mongodb/MongoExecutorTests.scala
@@ -117,7 +117,7 @@ class MongoExecutorTests extends FlatSpec with Matchers with BeforeAndAfterAll w
     val id = new ObjectId()
     val handler = new PromiseHandler("unitHandler",id)
     ex.subscribe(handler)
-    ex.postResult(id, 0, PiItem(0))
+    ex.postResult(id, 0, MetadataAtomicProcess.result(PiItem(0)))
       
     a [NoSuchInstanceException[ObjectId]] should be thrownBy await(handler.future)
 	}

--- a/test/com/workflowfm/pew/stateless/KafkaExecutorTests.scala
+++ b/test/com/workflowfm/pew/stateless/KafkaExecutorTests.scala
@@ -53,7 +53,7 @@ class KafkaExecutorTests extends PewTestSuite with KafkaTests {
 
     val c1 = KafkaConnectors.indyReducer( new Reducer )
     val c2 = KafkaConnectors.indySequencer
-    val c3 = KafkaConnectors.indyAtomicExecutor( AtomicExecutor() )
+    val c3 = KafkaConnectors.indyAtomicExecutor( new AtomicExecutor() )
     val c4 = KafkaConnectors.uniqueResultListener( listener )
 
     val pii = PiInstance( ObjectId.get, pbi, PiObject(1) )

--- a/test/com/workflowfm/pew/stateless/component/KafkaAtomicExecTests.scala
+++ b/test/com/workflowfm/pew/stateless/component/KafkaAtomicExecTests.scala
@@ -39,7 +39,7 @@ class KafkaAtomicExecTests extends PewTestSuite with KafkaExampleTypes {
     )
 
   it should "respond to Assignments with a correct SequenceRequest" in {
-    val atomExec: AtomicExecutor = AtomicExecutor()
+    val atomExec: AtomicExecutor = new AtomicExecutor()
 
     val (threads, pii)
     = PiInstance( ObjectId.get, pbi, PiObject(1) )
@@ -63,7 +63,7 @@ class KafkaAtomicExecTests extends PewTestSuite with KafkaExampleTypes {
       = MockTracked
         .source( history )
         .groupBy( Int.MaxValue, _.part )
-        .via( flowRespond( AtomicExecutor() ) )
+        .via( flowRespond( new AtomicExecutor() ) )
         .via( flowWaitFuture( 1 )( completeProcess.settings ) )
         .mergeSubstreams
         .runWith(Sink.seq)(ActorMaterializer())


### PR DESCRIPTION
Made `MetadataAtomicProcess` the default and `AtomicProcess` the sub-trait. I don't love the name "MetadataAtomicProcess" so might change it.
Various other minor changes.