### PR TITLE
PiEventCallCodec: Cast to MetadataAtomicProcess instead of AtomicProc…

### DIFF
--- a/src/com/workflowfm/pew/mongodb/bson/events/PiEventCallCodec.scala
+++ b/src/com/workflowfm/pew/mongodb/bson/events/PiEventCallCodec.scala
@@ -47,9 +47,9 @@ class PiEventCallCodec[T](
 
     val ref: Int = reader.readInt32( callRefN )
 
-    val proc: AtomicProcess
+    val proc: MetadataAtomicProcess
       = ctx.decodeWithChildContext( procCodec, reader )
-        .asInstanceOf[AtomicProcess]
+        .asInstanceOf[MetadataAtomicProcess]
 
     val args: Seq[PiObject]
       = readArray( reader, argsN ) { () =>


### PR DESCRIPTION
…ess. Closes #37.