### PR TITLE
Fixed duplicate PiEventReturns within the Kafka PiiHistory.

### DIFF
--- a/src/com/workflowfm/pew/stateless/instances/kafka/components/SequenceResponseBuilder.scala
+++ b/src/com/workflowfm/pew/stateless/instances/kafka/components/SequenceResponseBuilder.scala
@@ -36,14 +36,10 @@ case class PartialResponse(
         if (errors.nonEmpty) {
           if (hasPayload) errors.map( PiiLog( _ ) )
           else Seq( SequenceFailure( Right( pii ), returns, errors ) )
-
-        } else ReduceRequest( pii, returns ) +: returns.map( r => PiiLog( returnEvent( pii.id, r ) ) )
+        } else Seq( ReduceRequest( pii, returns ) )
 
       ).getOrElse( Seq() )
 
-  protected def returnEvent( id: ObjectId, callResult: CallResult ): PiEventReturn[ObjectId]
-    = PiEventReturn[ObjectId]( id, callResult._1.id, PiObject.get(callResult._2) )
-      
   /** Overwrite with the latest PiInstance information.
     */
   def update( newPii: PiInstance[ObjectId] ): PartialResponse


### PR DESCRIPTION
This cropped up when the PiEventReturn needed to be moved to the AtomicProcessExecutor because it needed the metadata to be available, but it was not removed from where it used to be in SequenceResponseBuilder. 